### PR TITLE
Unary operators

### DIFF
--- a/src/Errors/Character.js
+++ b/src/Errors/Character.js
@@ -21,8 +21,15 @@ export class InvalidNumber extends CharacterError {
     };
 };
 
+export class InvalidOperator extends CharacterError {
+    constructor(char){
+        super(char, 'Invalid operator');
+    };
+};
+
 export default {
     CharacterError,
     UnknownCharacter,
-    InvalidNumber
+    InvalidNumber,
+    InvalidOperator
 };

--- a/src/core/calculateTree.js
+++ b/src/core/calculateTree.js
@@ -4,7 +4,8 @@ import options from '../options';
 import { Token } from './lex';
 import { Node } from './parse';
 import Errors from '../Errors';
-const { min, max, pow } = Math;
+import { SIGBREAK } from 'constants';
+const { min, max, pow, sqrt } = Math;
 
 /**
  * Calculates the result of an expression.
@@ -16,29 +17,47 @@ export default function calculateTree(root){
     const token = root.value;
     if(token instanceof Token._Number) return root;
     
-    const l = calculateTree(root.left).value.value;
-    const r = calculateTree(root.right).value.value;
+    let result;
+    if(token instanceof Token.BinaryOperation){
+        const l = calculateTree(root.left).value.value;
+        const r = calculateTree(root.right).value.value;
+        
+        switch(token.constructor){
+            case Token.Addition:
+                result = round(l + r, max(precision(l), precision(r)));
+                break;
+            case Token.Substraction:
+                result = round(l - r, max(precision(l), precision(r)));
+                break;
+            case Token.Multiplication:
+                result = round(l * r, max(precision(l), precision(r)));
+                break;
+            case Token.Division:
+                if(r === 0) throw new Errors.Math.DivisionByZero(root.value, 'Cannot divide by zero');
+                result = round(l / r, max(options.precision, precision(l), precision(r)));
+                break;
+            case Token.Exponentiation:
+                result = round(pow(l, r), max(precision(l), precision(r)));
+                break;
+            case Token.SquareRoot:
+                result = round(sqrt());
+                break;
+            default:
+                throw new TypeError(`Invalid operand ${token.operator}`);
+        };
+    }
+    else if (token instanceof Token.UnaryOperation){
+        const value = calculateTree(root.left).value.value;
+
+        switch(token.constructor){
+            case Token.SquareRoot:
+                result = round(sqrt(value), max(precision(value), options.precision));
+                break;
+            default:
+                throw new TypeError(`Invalid operand ${token.name}`);
+        };
+    }
+    else throw new TypeError('Cannot calculate non-binary operation');
     
-    let value = null;
-    switch(token.constructor){
-        case Token.Addition:
-            value = round(l + r, max(precision(l), precision(r)));
-            break;
-        case Token.Substraction:
-            value = round(l - r, max(precision(l), precision(r)));
-            break;
-        case Token.Multiplication:
-            value = round(l * r, max(precision(l), precision(r)));
-            break;
-        case Token.Division:
-            if(r === 0) throw new Errors.Math.DivisionByZero(root.value, 'Cannot divide by zero');
-            value = round(l / r, max(options.precision, precision(l), precision(r)));
-            break;
-        case Token.Exponentiation:
-            value = round(pow(l, r), max(precision(l), precision(r)));
-            break;
-        default:
-            throw new TypeError('Cannot calculate non-binary operation');
-    };
-    return new Node(new Token._Number( value ));
+    return new Node(new Token._Number( result ));
 };

--- a/src/core/calculateTree.js
+++ b/src/core/calculateTree.js
@@ -5,7 +5,7 @@ import { Token } from './lex';
 import { Node } from './parse';
 import Errors from '../Errors';
 import { SIGBREAK } from 'constants';
-const { min, max, pow, sqrt } = Math;
+const { min, max, pow, sqrt, cos, sin, tan } = Math;
 
 /**
  * Calculates the result of an expression.
@@ -39,9 +39,6 @@ export default function calculateTree(root){
             case Token.Exponentiation:
                 result = round(pow(l, r), max(precision(l), precision(r)));
                 break;
-            case Token.SquareRoot:
-                result = round(sqrt());
-                break;
             default:
                 throw new TypeError(`Invalid operand ${token.operator}`);
         };
@@ -53,6 +50,16 @@ export default function calculateTree(root){
             case Token.SquareRoot:
                 result = round(sqrt(value), max(precision(value), options.precision));
                 break;
+            case Token.Cos:
+                result = round(cos(value), max(precision(value), options.precision));
+                break;
+            case Token.Sin:
+                result = round(sin(value), max(precision(value), options.precision));
+                break;
+            case Token.Tan:
+                result = round(tan(value), max(precision(value), options.precision));
+                break;
+                
             default:
                 throw new TypeError(`Invalid operand ${token.name}`);
         };

--- a/src/core/lex/Token.js
+++ b/src/core/lex/Token.js
@@ -7,6 +7,33 @@ class _Number {
     };
 };
 
+class UnaryOperation {
+    constructor(name){
+        this.name = name;
+    };
+};
+
+class SquareRoot extends UnaryOperation {
+    constructor(){
+        super('sqrt');
+    };
+};
+class Sin extends UnaryOperation {
+    constructor(){
+        super('sin');
+    };
+};
+class Cos extends UnaryOperation {
+    constructor(){
+        super('cos');
+    };
+};
+class Tan extends UnaryOperation {
+    constructor(){
+        super('tan');
+    };
+};
+
 class BinaryOperation {
     constructor(operator, precedence){
         this.operator = operator;
@@ -51,7 +78,9 @@ class CloseParenthesis {
 
 export default {
     _Number,
+    UnaryOperation,
+        SquareRoot, Sin, Cos, Tan,
     BinaryOperation,
-    Addition, Substraction, Division, Multiplication, Exponentiation,
+        Addition, Substraction, Division, Multiplication, Exponentiation,
     OpenParenthesis, CloseParenthesis,
 };

--- a/src/core/lex/Token.js
+++ b/src/core/lex/Token.js
@@ -11,6 +11,9 @@ class UnaryOperation {
     constructor(name){
         this.name = name;
     };
+    print(){
+        return this.name
+    }
 };
 
 class SquareRoot extends UnaryOperation {

--- a/src/core/lex/test/lex.test.js
+++ b/src/core/lex/test/lex.test.js
@@ -72,6 +72,31 @@ test('core/lex', main => {
                 t.equal(token.name, 'tan')
                 t.end();
             });
+            t.test('├── implicit multiplication', t => {
+                t.test('├─── sqrt(a)b', t => {
+                    const tokens = lex(':sqrt(5)2');
+                    t.deepEquals(tokens, [
+                        { name: 'sqrt' },
+                        {}, { value: 5 }, {},
+                        { operator: '*', precedence: 1, isParenthesized: null },
+                        { value: 2 }
+                    ]);
+                    t.end();
+                });
+                t.test('├─── b sqrt(a)', t => {
+                    const tokens = lex('2:sqrt(5)');
+                    t.deepEquals(tokens, [
+                        { value: 2 },
+                        { operator: '*', precedence: 1, isParenthesized: null},
+                        { name: 'sqrt' },
+                        {}, { value: 5 }, {}
+                    ]);
+                    t.end();
+                });
+            });
+            t.test('├── negative numbers', t => {
+                t.end();
+            });
             t.test('├── errors', t => {
                 t.throws(
                     () => lex(':xyz(2)')
@@ -80,11 +105,8 @@ test('core/lex', main => {
                     () => lex(':sqrt5')
                 , CharError.InvalidOperator, 'missing parentheses');
                 t.throws(
-                    () => lex('5:sqrt')
-                , CharError.InvalidNumber, 'missing parentheses');
-                t.throws(
                     () => lex('25bc')
-                , CharError.InvalidNumber, 'mixed digits and letters');
+                , CharError.UnknownCharacter, 'mixed digits and letters');
                 t.end();
             });
         });

--- a/src/core/lex/test/lex.test.js
+++ b/src/core/lex/test/lex.test.js
@@ -39,6 +39,55 @@ test('core/lex', main => {
                 t.end();
             });
         });
+        t.test('├─ unary operators', t => {
+            t.test('├── square root', t => {
+                const [ token, _, number ] = lex(':sqrt(2)')
+                t.ok(token instanceof Token.UnaryOperation, 'is a unary operator')
+                t.ok(token instanceof Token.SquareRoot, 'is a square root operation')
+                t.ok(number instanceof Token._Number, 'is a number')
+                t.equal(token.name, 'sqrt')
+                t.end();
+            });
+            t.test('├── sin', t => {
+                const [ token, _, number ] = lex(':sin(2)')
+                t.ok(token instanceof Token.UnaryOperation, 'is a unary operator')
+                t.ok(token instanceof Token.Sin, 'is a sin operation')
+                t.ok(number instanceof Token._Number, 'is a number')
+                t.equal(token.name, 'sin')
+                t.end();
+            });
+            t.test('├── cos', t => {
+                const [ token, _, number ] = lex(':cos(2)')
+                t.ok(token instanceof Token.UnaryOperation, 'is a unary operator')
+                t.ok(token instanceof Token.Cos, 'is a cos operation')
+                t.ok(number instanceof Token._Number, 'is a number')
+                t.equal(token.name, 'cos')
+                t.end();
+            });
+            t.test('├── tan', t => {
+                const [ token, _, number ] = lex(':tan(2)')
+                t.ok(token instanceof Token.UnaryOperation, 'is a unary operator')
+                t.ok(token instanceof Token.Tan, 'is a tan operation')
+                t.ok(number instanceof Token._Number, 'is a number')
+                t.equal(token.name, 'tan')
+                t.end();
+            });
+            t.test('├── errors', t => {
+                t.throws(
+                    () => lex(':xyz(2)')
+                , CharError.InvalidOperator, 'invalid keyword');
+                t.throws(
+                    () => lex(':sqrt5')
+                , CharError.InvalidOperator, 'missing parentheses');
+                t.throws(
+                    () => lex('5:sqrt')
+                , CharError.InvalidNumber, 'missing parentheses');
+                t.throws(
+                    () => lex('25bc')
+                , CharError.InvalidNumber, 'mixed digits and letters');
+                t.end();
+            });
+        });
         t.test('├─ binary operators', t => {
             t.test('├── +', t => {
                 const [ token ] = lex('+');

--- a/src/core/lex/tokenize.js
+++ b/src/core/lex/tokenize.js
@@ -25,7 +25,7 @@ function tokenizeDigits(digits){
     return new Token._Number(parseFloat(digits.join('')));
 };
 
-function createNonDigitTokenizer(TokenConstructor){
+function createCharacterTokenizer(TokenConstructor){
     return function(char, tokens, digits){
         const token = new TokenConstructor();
         return ({
@@ -59,13 +59,13 @@ const patterns = {
     '\\d': (digit, tokens, digits) => ({
         tokens, digits: digits.concat(digit)
     }),
-    '\\+': createNonDigitTokenizer(Token.Addition),
-    '\\-': createNonDigitTokenizer(Token.Substraction),
-    '\\/': createNonDigitTokenizer(Token.Division),
-    '\\*': createNonDigitTokenizer(Token.Multiplication),
-    '\\^': createNonDigitTokenizer(Token.Exponentiation),
-    '\\(': createNonDigitTokenizer(Token.OpenParenthesis),
-    '\\)': createNonDigitTokenizer(Token.CloseParenthesis),
+    '\\+': createCharacterTokenizer(Token.Addition),
+    '\\-': createCharacterTokenizer(Token.Substraction),
+    '\\/': createCharacterTokenizer(Token.Division),
+    '\\*': createCharacterTokenizer(Token.Multiplication),
+    '\\^': createCharacterTokenizer(Token.Exponentiation),
+    '\\(': createCharacterTokenizer(Token.OpenParenthesis),
+    '\\)': createCharacterTokenizer(Token.CloseParenthesis),
     '.': (char) => {
         throw new CharError.UnknownCharacter(char);
     },

--- a/src/core/lex/tokenize.js
+++ b/src/core/lex/tokenize.js
@@ -100,11 +100,15 @@ const patterns = {
         };
     },
     '\^[a-zA-Z]+$': (character, tokens, digits, operator) => {
-        if(digits.length) throw new CharError.InvalidNumber(digits.concat(character).join(''));
         if(!operator.length) throw new CharError.UnknownCharacter(character);
-        return {
-            tokens, digits, operator: operator.concat(character)
-        };
+        return digits.length 
+            ? {
+                tokens: tokens.concat(tokenizeDigits(digits)), digits: [], operator: operator.concat(character)
+            }
+            : {
+                tokens, digits, operator: operator.concat(character)
+            }
+        ;
     },
     '\\+': createCharacterTokenizer(Token.Addition),
     '\\-': createCharacterTokenizer(Token.Substraction),

--- a/src/core/lex/tokenize.js
+++ b/src/core/lex/tokenize.js
@@ -7,14 +7,18 @@ import CharError from '../../Errors/Character';
  * @param {String} expression 
  */
 export default function tokenize(expression){
-    const { tokens, digits } = expression.split('').reduce(
-        ({ tokens, digits }, char, index) => {
+    const { tokens, digits, operator } = expression.split('').reduce(
+        ({ tokens, digits, operator }, char, index) => {
             const [ _, tokenizer ] = Object.entries(patterns).find(
                 ([ pattern ]) => new RegExp(pattern).test(char)
             );
-            return tokenizer(char, tokens, digits);
+            return tokenizer(char, tokens, digits, operator);
         }
-    , { tokens: [], digits: [] });
+    , { tokens: [], digits: [], operator: [] });
+
+    if(operator.length){
+        throw new CharError.InvalidOperator(operator.concat(digit).join(''));
+    };
     return digits.length > 0
         ? tokens.concat(tokenizeDigits(digits))   
         : tokens
@@ -24,15 +28,30 @@ export default function tokenize(expression){
 function tokenizeDigits(digits){
     return new Token._Number(parseFloat(digits.join('')));
 };
+function tokenizeOperator(operator){
+    const name = operator.slice(1).join('');
+    const token = {
+        'sqrt': new Token.SquareRoot(),
+        'cos': new Token.Cos(),
+        'sin': new Token.Sin(),
+        'tan': new Token.Tan(),
+    }[name];
+    if(!token) throw new CharError.InvalidOperator()
+    return token;
+}
 
 function createCharacterTokenizer(TokenConstructor){
-    return function(char, tokens, digits){
+    return function(char, tokens, digits, operator){
+        if(operator.length){
+            throw new CharError.InvalidOperator(operator.concat(digit).join(''));
+        };
+
         const token = new TokenConstructor();
         return ({
             tokens: digits.length === 0
                 ? tokens.concat(token)
                 : tokens.concat( tokenizeDigits(digits), token),
-            digits: []
+            digits: [], operator: []
         });
     };
 };
@@ -44,27 +63,68 @@ function createCharacterTokenizer(TokenConstructor){
  * They must return an object with keys { tokens, digits } coresponding to the new tokens and digits.
  */
 const patterns = {
-    '\\s': (whitespace, tokens, digits) => ({
-        tokens: digits.length === 0
-            ? tokens
-            : tokens.concat(tokenizeDigits(digits)),
-        digits: []
-    }),
-    '\\.': (point, tokens, digits) => {
+    '\\s': (whitespace, tokens, digits, operator) => {
+        if(operator.length){
+            throw new CharError.InvalidOperator(operator.concat(digit).join(''));
+        };
+        return {
+            tokens: digits.length === 0
+                ? tokens
+                : tokens.concat(tokenizeDigits(digits)),
+            digits: [],
+            operator: []
+        };
+    },
+    '\\.': (point, tokens, digits, operator) => {
         if(digits.length === 0){
             throw new CharError.InvalidNumber(point);
+        } else if(operator.length){
+            throw new CharError.InvalidOperator(operator.concat(digit).join(''));
         };
-        return { tokens, digits: digits.concat(point) };
+        return { tokens, digits: digits.concat(point), operator };
     },
-    '\\d': (digit, tokens, digits) => ({
-        tokens, digits: digits.concat(digit)
-    }),
+    '\\d': (digit, tokens, digits, operator) => {
+        if(operator.length){
+            throw new CharError.InvalidOperator(operator.concat(digit).join(''));
+        };
+        return {
+            tokens, digits: digits.concat(digit), operator
+        };
+    },
+    '\:': (colon, tokens, digits, operator) => {
+        if(operator.length){
+            throw new CharError.InvalidOperator(operator.concat(digit).join(''));
+        };
+        return {
+            tokens, digits, operator: [colon]
+        };
+    },
+    '\^[a-zA-Z]+$': (character, tokens, digits, operator) => {
+        if(digits.length) throw new CharError.InvalidNumber(digits.concat(character).join(''));
+        if(!operator.length) throw new CharError.UnknownCharacter(character);
+        return {
+            tokens, digits, operator: operator.concat(character)
+        };
+    },
     '\\+': createCharacterTokenizer(Token.Addition),
     '\\-': createCharacterTokenizer(Token.Substraction),
     '\\/': createCharacterTokenizer(Token.Division),
     '\\*': createCharacterTokenizer(Token.Multiplication),
     '\\^': createCharacterTokenizer(Token.Exponentiation),
-    '\\(': createCharacterTokenizer(Token.OpenParenthesis),
+    '\\(': (openParenthesis, tokens, digits, operator) => {
+        if(operator.length){
+            return {
+                tokens: tokens.concat(tokenizeOperator(operator), new Token.OpenParenthesis()),
+                digits: [], operator: []
+            };
+        }
+        return {
+            tokens: digits.length === 0
+                ? tokens.concat(new Token.OpenParenthesis())
+                : tokens.concat( tokenizeDigits(digits), new Token.OpenParenthesis()),
+            digits: [], operator: []
+        };
+    },
     '\\)': createCharacterTokenizer(Token.CloseParenthesis),
     '.': (char) => {
         throw new CharError.UnknownCharacter(char);

--- a/src/core/lex/transform.js
+++ b/src/core/lex/transform.js
@@ -66,11 +66,20 @@ const transformations = [
     function implicitMultiplication(tokens, token, index){
         if ((token instanceof Token._Number) || (token instanceof Token.CloseParenthesis)){
             const next = tokens[index + 1];
-            if(next instanceof Token.OpenParenthesis) {
+            if((next instanceof Token.OpenParenthesis) || (next instanceof Token.UnaryOperation) || (next instanceof Token._Number)) {
                 return [
                 ...tokens.slice(0, index + 1),
                 new Token.Multiplication(),
                 ...tokens.slice(index + 1)
+                ];
+            }
+        } else if (token instanceof Token.UnaryOperation){
+            const next = tokens[index + 1];
+            if((next instanceof Token.UnaryOperation) || (next instanceof Token._Number)){
+                return [
+                    ...tokens.slice(0, index + 1),
+                    new Token.Multiplication(),
+                    ...tokens.slice(index + 1)
                 ];
             };
         };

--- a/src/core/parse/parse.js
+++ b/src/core/parse/parse.js
@@ -88,12 +88,28 @@ const expectedTokens = [
             };
             leaf.add(node);
             return { root, leaf: root };
-        }
+        };
+        return false;
+    },
+    function unaryOperation(token){
+        if(token instanceof Token.UnaryOperation) return function parseUnaryOperation(root, leaf){
+            console.log({ token, root, leaf})
+            const node = new Node(token);
+            if(root === null) {
+                return {
+                    root: node, leaf: node
+                };
+            };
+            leaf.add(node);
+            return {
+                root, leaf: node
+            };
+        };
         return false;
     },
     function binaryOperation(token){
         if(token instanceof Token.BinaryOperation) return function parseBinaryOperation(root, leaf){
-            if(root === null) throw new _SyntaxError.MissingNumber(token)
+            if(root === null) throw new _SyntaxError.MissingNumber(token);
             if((root.value instanceof Token.BinaryOperation) &&
                 (!root.value.isParenthesized && (token.precedence > root.value.precedence))
             ){

--- a/src/core/parse/test/parse.test.js
+++ b/src/core/parse/test/parse.test.js
@@ -435,6 +435,22 @@ test('core/parse', main => {
                 t.end();
             });
         });
+        t.test('├─ unary operations', t => {
+            t.test('├── no value', t => {
+                t.throws(
+                    () => parse(lex(':sqrt()')),
+                    _SyntaxError.EmptyExpression
+                );
+                t.end();
+            });
+            t.test('├── no closing parenthesis', t => {
+                t.throws(
+                    () => parse(lex(':sqrt(5')),
+                    _SyntaxError.UnmatchedParenthesis
+                );
+                t.end();
+            });
+        });
         t.test('├─ parentheses', t => {
             t.test('├── no closing parenthesis ', t => {
                 t.throws(

--- a/src/core/parse/test/parse.test.js
+++ b/src/core/parse/test/parse.test.js
@@ -18,8 +18,79 @@ test('core/parse', main => {
         t.equal(root.value.value, -1);
         t.end();
     });
-
-    main.test('├ simple expressions', t => {
+    main.test('├─ simple expressions with unary operations', t => {
+        t.test('├── sqrt', t => {
+            const tokens = lex(':sqrt(1)');
+            const root = parse(tokens);
+            t.ok(root.value instanceof Token.SquareRoot, 'root is a square root operation');
+            t.ok(root.left.value instanceof Token._Number, 'left is a number');
+            t.end();
+        })
+        t.test('├── sin', t => {
+            const tokens = lex(':sin(1)');
+            const root = parse(tokens);
+            t.ok(root.value instanceof Token.Sin, 'root is a sin operation');
+            t.ok(root.left.value instanceof Token._Number, 'left is a number');
+            t.end();
+        })
+        t.test('├── cos', t => {
+            const tokens = lex(':cos(1)');
+            const root = parse(tokens);
+            t.ok(root.value instanceof Token.Cos, 'root is a cos operation');
+            t.ok(root.left.value instanceof Token._Number, 'left is a number');
+            t.end();
+        })
+        t.test('├── tan', t => {
+            const tokens = lex(':tan(1)');
+            const root = parse(tokens);
+            t.ok(root.value instanceof Token.Tan, 'root is a tan operation');
+            t.ok(root.left.value instanceof Token._Number, 'left is a number');
+            t.end();
+        })
+    })
+    main.test('├ more complex unary operations', t => {
+        t.test('├─ cos(a+b)', t => {
+            const tokens = lex(':cos(1+2)');
+            const root = parse(tokens);
+            const walk = Array.from(root.walk());
+            t.deepEqual(walk, [
+                { name: 'cos' },
+                { operator: '+', precedence: 0, isParenthesized: true },
+                { value: 1 },
+                { value: 2 }
+            ]);
+            t.end();
+        });
+        t.test('├─ a + b * sqrt(a)', t => {
+            const tokens = lex('1 + 2 * :sqrt(5)');
+            const root = parse(tokens);
+            const walk = Array.from(root.walk());
+            t.deepEqual(walk, [
+                { operator: '+', precedence: 0, isParenthesized: null },
+                { value: 1 },
+                { operator: '*', precedence: 1, isParenthesized: null },
+                { value: 2 },
+                { name: 'sqrt' },
+                { value: 5 },
+            ]);
+            t.end();
+        });
+        t.test('├─ sqrt(a) b + c', t => {
+            const tokens = lex(':sqrt(50) 20 + 40');
+            const root = parse(tokens);
+            const walk = Array.from(root.walk());
+            t.deepEqual(walk, [
+                { operator: '+', precedence: 0, isParenthesized: null },
+                { operator: '*', precedence: 1, isParenthesized: null },
+                { name: 'sqrt' },
+                { value: 50 },
+                { value: 20 },
+                { value: 40 }
+            ]);
+            t.end();
+        });
+    })
+    main.test('├ simple binary expressions', t => {
         t.test('├─ addition', t => {
             const tokens = lex('10 + 2.5');
             const root = parse(tokens);

--- a/src/core/printTree.js
+++ b/src/core/printTree.js
@@ -12,17 +12,30 @@ export default function printTree(root, separator=''){
             token.print(),
             printBinaryOperationChildNode(token, root.right, separator)
         ].join(separator);
-    } else {
+    } else if (token instanceof Token.UnaryOperation){
+        return [
+            token.print(),
+            printUnaryOperationChildNode(token, root.left, separator)
+        ].join(separator)
+    }
+    else {
         throw new Error('cannot print invalid tree');
     };
 };
 
+function printUnaryOperationChildNode(unaryOperationToken, node, separator){
+    const token = node.value;
+    return [
+        '(',
+        printTree(node),
+        ')'
+    ].join(separator)
+}
+
 function printBinaryOperationChildNode(binaryOperationToken, node, separator){
     const token = node.value;
-    return token instanceof Token.BinaryOperation
-        ? binaryOperationToken.isParenthesized || token.precedence < binaryOperationToken.precedence
-            ? ['(', printTree(node, separator), ')'].join(separator)
-            : printTree(node, separator)
-        : token.print()
+    return (token instanceof Token.BinaryOperation) && binaryOperationToken.isParenthesized || token.precedence < binaryOperationToken.precedence
+        ? ['(', printTree(node, separator), ')'].join(separator)
+        : printTree(node, separator)
     ;
 };

--- a/src/core/simplifyTree.js
+++ b/src/core/simplifyTree.js
@@ -5,8 +5,10 @@ import options from '../options';
 import { Token } from './lex';
 import { Node } from './parse';
 import Errors from '../Errors';
+import calculateTree from './calculateTree'
 
 const { min, max, pow } = Math;
+
 
 /**
  * simplifyTree
@@ -62,7 +64,7 @@ export default function simplifyTree(root){
     const rightToken = rightNode.value;
 
     return (rightToken instanceof Token._Number) && (leftToken instanceof Token._Number)
-        ? calculateTree(token, leftToken, rightToken)
+        ? calculateOrSimplifyTree(root, leftToken, rightToken)
         : simplifyDivision(token, leftNode, rightNode)
     ;
 };
@@ -80,7 +82,8 @@ export default function simplifyTree(root){
  * @param {Token} rightToken 
  * @returns {Node}
  */
-function calculateTree(operationToken, leftToken, rightToken){
+function calculateOrSimplifyTree(root, leftToken, rightToken){
+    const operationToken = root.value;
     let value;
     const l = leftToken.value;
     const r = rightToken.value;
@@ -101,23 +104,7 @@ function calculateTree(operationToken, leftToken, rightToken){
                 new Node(new Token._Number(newR))
             )
         ;
-    } else {
-        const places = max(precision(r), precision(l));
-        const value = operationToken instanceof Token.Addition
-            ? round(l + r, places)
-            : operationToken instanceof Token.Substraction
-            ? round(l - r, places)
-            : operationToken instanceof Token.Multiplication
-            ? round(l * r, places)
-            : operationToken instanceof Token.Exponentiation
-            ? round(pow(l, r), places)
-            : null
-        ;
-        if(value === null){
-            throw new TypeError('Cannot calculate non-binary operation');
-        };
-        return new Node(new Token._Number(value));
-    };
+    } else return calculateTree(root)
 };
 
 /**

--- a/src/core/test/calculateTree.test.js
+++ b/src/core/test/calculateTree.test.js
@@ -41,8 +41,15 @@ test('core/calculateTree', main => {
             });
             t.end();
         });
+        t.test('├─ with :sqrt', t => {
+            const node = calculateTree(parse(lex(':sqrt(25)'))); 
+            t.ok(node instanceof Node);
+            t.ok(node.value instanceof Token._Number);
+            t.deepEqual(node.value, { value: 5 });
+            t.end();
+        });
         t.test('├─ nested operation', t => {
-            const node = calculateTree(parse(lex('10 / 2 + 5'))); 
+            const node = calculateTree(parse(lex('10 / 2 + :sqrt(25)'))); 
             t.ok(node instanceof Node);
             t.ok(node.value instanceof Token._Number);
             t.deepEqual(node.value, { value: 10 });

--- a/src/core/test/calculateTree.test.js
+++ b/src/core/test/calculateTree.test.js
@@ -48,6 +48,27 @@ test('core/calculateTree', main => {
             t.deepEqual(node.value, { value: 5 });
             t.end();
         });
+        t.test('├─ with :cos', t => {
+            const node = calculateTree(parse(lex(':cos(25)'))); 
+            t.ok(node instanceof Node);
+            t.ok(node.value instanceof Token._Number);
+            t.deepEqual(node.value, { value: 0.991 });
+            t.end();
+        });
+        t.test('├─ with :sin', t => {
+            const node = calculateTree(parse(lex(':sin(25)'))); 
+            t.ok(node instanceof Node);
+            t.ok(node.value instanceof Token._Number);
+            t.deepEqual(node.value, { value: -0.132 });
+            t.end();
+        });
+        t.test('├─ with :tan', t => {
+            const node = calculateTree(parse(lex(':tan(25)'))); 
+            t.ok(node instanceof Node);
+            t.ok(node.value instanceof Token._Number);
+            t.deepEqual(node.value, { value: -0.134 });
+            t.end();
+        });
         t.test('├─ nested operation', t => {
             const node = calculateTree(parse(lex('10 / 2 + :sqrt(25)'))); 
             t.ok(node instanceof Node);

--- a/src/core/test/printTree.test.js
+++ b/src/core/test/printTree.test.js
@@ -32,6 +32,10 @@ test('core/printTree', main => {
             printTree(parse(lex('20^1'))),
             '20^1'
         );
+        t.equal(
+            printTree(parse(lex(':sqrt(15)'))),
+            'sqrt(15)'
+        );
         t.end();
     });
     main.test('├ tree', t => {
@@ -62,6 +66,18 @@ test('core/printTree', main => {
         t.equal(
             printTree(parse(lex('(1+1)/(2+2)(3+3)'))),
             '(1+1)/(2+2)*(3+3)'
+        );
+        t.equal(
+            printTree(parse(lex(':sqrt(5*5)'))),
+            'sqrt(5*5)'
+        );
+        t.equal(
+            printTree(parse(lex(':sqrt(5*5)+2'))),
+            'sqrt(5*5)+2'
+        );
+        t.equal(
+            printTree(parse(lex('1:sqrt(5*5)+2'))),
+            '1*sqrt(5*5)+2'
         );
         t.end();
     });

--- a/src/test/calculate.test.js
+++ b/src/test/calculate.test.js
@@ -52,6 +52,11 @@ test('/calculate', main => {
             t.equal(calculate('2 ^ 2'), 4);
             t.end();
         });
+        t.test('├─ with :sqrt', t => {
+            t.equal(calculate(':sqrt(100)'), 10);
+            t.equal(calculate(':sqrt(3)'), 1.732);
+            t.end();
+        });
         t.test('├─ result should always be in the same precision as the most precise input', t => {
             t.equal(calculate('1.11111 + 0'), 1.11111)
             t.end()
@@ -97,6 +102,8 @@ test('/calculate', main => {
         t.equal(calculate('5(10^2)(12-9)'), 1500);
         t.equal(calculate('2/4/8'), 0.063);
         t.equal(calculate('2/(4/8)'), 4);
+        t.equal(calculate(':sqrt(10^2)+1'), 11);
+        t.equal(calculate('(10+2-5)*10:sqrt(10^2)+1'), 701);
         t.end();
     });
     main.test('├ errors', t => {


### PR DESCRIPTION
Add support for unary operators.

Syntax: `2+:sqrt(5*5)`
`:cos(5)`